### PR TITLE
Point at the right location for types.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "Shai Nagar",
   "license": "MIT",
   "types": "./dist/types/index.d.ts",
-  "exports": "./dist/index.js",
+  "exports": ["./dist/index.js", "./dist/types/index.d.ts"],
   "keywords": [
     "dag",
     "directed-acyclic-graph",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "https://github.com/sha1n/dagraph",
   "author": "Shai Nagar",
   "license": "MIT",
-  "types": "./dist/index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "exports": "./dist/index.js",
   "keywords": [
     "dag",


### PR DESCRIPTION
When installing from npm I got some errors about types. Turns out they seem to be referred to in the wrong way from the package.json.

Cheers