### PR TITLE
Allow imports from esm.

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -163,3 +163,4 @@ function createDAG<T extends Identifiable>(): DAGraph<T> {
 
 export type { DAGraph, Identifiable };
 export default createDAG;
+export { createDAG };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@sha1n/dagraph",
   "version": "0.0.5",
+  "type": "commonjs",
   "description": "Directed acyclic graph utility in TypeScript",
   "repository": "https://github.com/sha1n/dagraph",
   "author": "Shai Nagar",


### PR DESCRIPTION
Hey I found my setup struggled with the way exports are set up.

Recently node switched the default package type being "module" which your code isn't set up as ESM yet. 

This gets things working in my env at least. Just have to do this to import: `import {createDAG} from "@sha1n/dagraph"`

Cheers @sha1n !


![image](https://github.com/sha1n/dagraph/assets/229943/b731f451-0bd1-4af8-a95c-c746d6de48dc)
