### PR TITLE
fix: resolve critical and high handlebars CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "node": ">= 24"
   },
   "resolutions": {
+    "handlebars": "^4.7.9",
     "json5": "^2.2.3",
     "socks": "^2.8.3",
     "js-yaml": "^4.1.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  handlebars: ^4.7.9
   json5: ^2.2.3
   socks: ^2.8.3
   js-yaml: ^4.1.1
@@ -972,8 +973,8 @@ packages:
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
-  handlebars@4.7.8:
-    resolution: {integrity: sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==}
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
     engines: {node: '>=0.4.7'}
     hasBin: true
 
@@ -2781,7 +2782,7 @@ snapshots:
 
   graceful-fs@4.2.11: {}
 
-  handlebars@4.7.8:
+  handlebars@4.7.9:
     dependencies:
       minimist: 1.2.8
       neo-async: 2.6.2
@@ -3528,7 +3529,7 @@ snapshots:
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      handlebars: 4.7.8
+      handlebars: 4.7.9
       jest: 29.7.0(@types/node@24.12.0)(ts-node@10.9.2(@types/node@24.12.0)(typescript@4.9.5))
       json5: 2.2.3
       lodash.memoize: 4.1.2


### PR DESCRIPTION
## Summary
- Adds `"handlebars": "^4.7.9"` resolution override to force-patch the transitive handlebars dependency (pulled in via ts-jest)
- Resolves 5 Dependabot alerts: 1 critical (JS injection via AST type confusion) and 4 high (additional injection and DoS vectors)
- Dev-only dependency — zero impact on published package consumers

## Dependabot alerts addressed
| Alert | Severity | Summary |
|-------|----------|---------|
| #57 | Critical | Handlebars.js JavaScript Injection via AST Type Confusion |
| #58 | High | JavaScript Injection via AST Type Confusion by tampering @partial-block |
| #59 | High | Denial of Service via Malformed Decorator Syntax |
| #60 | High | JavaScript Injection via AST Type Confusion (dynamic partial) |
| #61 | High | JavaScript Injection in CLI Precompiler via Unescaped Names |

## Note on remaining picomatch alert (#53)
The high-severity picomatch ReDoS alert cannot be resolved via upgrades — even Jest 30 still pulls `picomatch@2.x` through `anymatch` and `micromatch`. This is dev-only and not exploitable by library consumers.

## Test plan
- [x] All 27 tests pass
- [x] Lint passes
- [x] Verified `handlebars@4.7.9` in lockfile
- [x] Confirmed no production dependencies affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)